### PR TITLE
Fix AI provider fallback + CI vet error, add multi-finding AI report

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -572,6 +572,7 @@ func SetupAPI() *gin.Engine {
 		// AI finding validation & reporting
 		apiGroup.POST("/findings/validate", apiValidateFinding)
 		apiGroup.POST("/findings/report", apiReportFinding)
+		apiGroup.POST("/findings/report-batch", apiReportFindingsBatch)
 		// KeyHack templates
 		apiGroup.GET("/keyhacks", apiListKeyhacks)
 		apiGroup.GET("/keyhacks/search", apiSearchKeyhacks)

--- a/internal/api/programs_api.go
+++ b/internal/api/programs_api.go
@@ -84,27 +84,35 @@ func apiListPrograms(c *gin.Context) {
 	sortBy := c.DefaultQuery("sort", "name")
 	forceRefresh := c.DefaultQuery("refresh", "false") == "true"
 
-	// A manual "refresh now" rebuilds in the background (the rebuild makes ~1000
-	// upstream calls and takes ~a minute — far too long to block the request on).
-	// We kick it off and still serve the current cache instantly below.
-	if forceRefresh {
-		refreshProgramsCacheAsync()
-	}
+	// The DB-backed cache is only usable when a DB is configured. Without it we
+	// skip all cache/background-refresh logic and just do a live fetch (the
+	// original behavior) — otherwise every request would kick an expensive
+	// upstream rebuild that can never be persisted.
+	cacheOn := programsCacheEnabled()
 
-	// Warm-cache fast path: serve the pre-fetched payload (scope already baked in)
-	// instantly. If it is stale, refresh in the background and still serve now.
-	if payload, ok := loadProgramsCache(); ok && len(payload.Programs) > 0 {
-		stale := time.Since(payload.GeneratedAt) > programsCacheTTL
-		if stale && !forceRefresh {
+	if cacheOn {
+		// A manual "refresh now" rebuilds in the background (the rebuild makes ~1000
+		// upstream calls and takes ~a minute — far too long to block the request on).
+		// We kick it off and still serve the current cache instantly below.
+		if forceRefresh {
 			refreshProgramsCacheAsync()
 		}
-		serveProgramsPayload(c, payload, platform, sortBy, stale)
-		return
-	}
 
-	// Cold path (cache not built yet): fall back to a live fetch so the first-ever
-	// load still works, and kick a background build so the next load is instant.
-	defer refreshProgramsCacheAsync()
+		// Warm-cache fast path: serve the pre-fetched payload (scope already baked in)
+		// instantly. If it is stale, refresh in the background and still serve now.
+		if payload, ok := loadProgramsCache(); ok && len(payload.Programs) > 0 {
+			stale := time.Since(payload.GeneratedAt) > programsCacheTTL
+			if stale && !forceRefresh {
+				refreshProgramsCacheAsync()
+			}
+			serveProgramsPayload(c, payload, platform, sortBy, stale)
+			return
+		}
+
+		// Cold path (cache not built yet): fall back to a live fetch so the first-ever
+		// load still works, and kick a background build so the next load is instant.
+		defer refreshProgramsCacheAsync()
+	}
 
 	var allPrograms []ProgramSummary
 	var mu sync.Mutex

--- a/internal/api/programs_cache.go
+++ b/internal/api/programs_cache.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,6 +48,16 @@ var (
 	programsRefreshMu  sync.Mutex
 	programsRefreshing bool
 )
+
+// programsCacheEnabled reports whether the DB-backed cache should be used at all.
+// Without a DB configured there is nowhere to persist the payload, so the cache
+// (and its background refresh) is disabled — the handler then just does a live
+// fetch, exactly as it did before this cache existed. This prevents a DB-less
+// deployment from triggering an endless loop of expensive upstream rebuilds that
+// can never be saved.
+func programsCacheEnabled() bool {
+	return strings.TrimSpace(os.Getenv("DB_HOST")) != ""
+}
 
 // loadProgramsCache reads and unmarshals the persisted payload.
 // ok is false when the cache is absent or unreadable.

--- a/internal/api/ui/pages/scan-detail.js
+++ b/internal/api/ui/pages/scan-detail.js
@@ -14,6 +14,34 @@
   const escAttr = (...args) => window.escAttr(...args);
   const copyToClipboard = (...args) => window.copyToClipboard(...args);
 
+  // showReportModal renders generated AI report text in a copyable overlay.
+  function showReportModal(title, text) {
+    document.getElementById('ai-report-modal')?.remove();
+    const overlay = document.createElement('div');
+    overlay.id = 'ai-report-modal';
+    overlay.style.cssText = 'position:fixed;inset:0;z-index:10000;background:rgba(2,6,23,.72);display:flex;align-items:center;justify-content:center;padding:24px;backdrop-filter:blur(2px)';
+    overlay.innerHTML = `
+      <div style="background:var(--bg-card,#0b1220);border:1px solid var(--border,rgba(255,255,255,.12));border-radius:12px;max-width:860px;width:100%;max-height:86vh;display:flex;flex-direction:column;box-shadow:0 20px 60px rgba(0,0,0,.5)">
+        <div style="display:flex;align-items:center;gap:12px;padding:14px 18px;border-bottom:1px solid var(--border,rgba(255,255,255,.1))">
+          <div style="font-weight:600;font-size:14px;color:var(--text-primary,#fff);flex:1">${esc(title)}</div>
+          <button type="button" id="ai-report-copy" style="padding:6px 12px;background:rgba(52,211,153,.12);border:1px solid rgba(52,211,153,.4);border-radius:6px;color:#34d399;font-size:12px;cursor:pointer">Copy</button>
+          <button type="button" id="ai-report-close" style="padding:6px 12px;background:rgba(255,255,255,.06);border:1px solid var(--border,rgba(255,255,255,.15));border-radius:6px;color:var(--text-secondary,#cbd5e1);font-size:12px;cursor:pointer">Close</button>
+        </div>
+        <pre id="ai-report-body" style="margin:0;padding:18px;overflow:auto;white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px;line-height:1.55;color:var(--text-primary,#e2e8f0)"></pre>
+      </div>`;
+    overlay.querySelector('#ai-report-body').textContent = text;
+    const close = () => overlay.remove();
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(); });
+    overlay.querySelector('#ai-report-close').addEventListener('click', close);
+    overlay.querySelector('#ai-report-copy').addEventListener('click', async () => {
+      try { await copyToClipboard(text); showToast('success', 'Copied', 'Report copied to clipboard'); }
+      catch (e) { showToast('error', 'Copy failed', e.message || String(e)); }
+    });
+    const onKey = (e) => { if (e.key === 'Escape') { close(); document.removeEventListener('keydown', onKey); } };
+    document.addEventListener('keydown', onKey);
+    document.body.appendChild(overlay);
+  }
+
   // ── State for Scan Detail Page ──────────────────────────────────────────
   window._scanDetailKnownFiles = new Set();
   window._scanDetailRefreshTimer = null;
@@ -900,6 +928,7 @@
             <div id="recon-quick-tools" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:8px 10px;border-bottom:1px solid var(--border);background:rgba(2,6,23,.38)">
               <div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap">
                 <button type="button" id="recon-copy-selected-tsv" title="Copy checked rows from the current page" style="padding:6px 10px;background:rgba(34,211,238,.1);border:1px solid rgba(34,211,238,.35);border-radius:6px;color:var(--accent-cyan);font-size:11px;cursor:pointer;white-space:nowrap"> Copy selected</button>
+                <button type="button" id="recon-report-selected-ai" title="Generate an AI vulnerability report for the checked rows" style="padding:6px 10px;background:rgba(52,211,153,.1);border:1px solid rgba(52,211,153,.4);border-radius:6px;color:#34d399;font-size:11px;cursor:pointer;white-space:nowrap"> Report selected (AI)</button>
                 <button type="button" id="recon-export-all-json" title="Export all findings in the current view as Markdown" style="padding:6px 10px;background:rgba(167,139,250,.08);border:1px solid rgba(167,139,250,.35);border-radius:6px;color:#c4b5fd;font-size:11px;cursor:pointer;white-space:nowrap"> Export Markdown</button>
               </div>
               <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
@@ -1197,6 +1226,7 @@
     };
     const copyTsvBtn = root.querySelector('#recon-copy-selected-tsv');
     const exportJsonBtn = root.querySelector('#recon-export-all-json');
+    const reportAiBtn = root.querySelector('#recon-report-selected-ai');
     if (copyTsvBtn) {
       copyTsvBtn.addEventListener('click', async () => {
         const rows = collectCheckedFindingRows();
@@ -1207,6 +1237,43 @@
           showToast('success', 'Copied', `${rows.length} row(s) as TSV`);
         } catch (e) {
           showToast('error', 'Copy failed', e.message || String(e));
+        }
+      });
+    }
+    if (reportAiBtn) {
+      reportAiBtn.addEventListener('click', async () => {
+        const rows = collectCheckedFindingRows();
+        if (!rows.length) { showToast('info', 'Nothing selected', 'Check one or more findings, then generate a report.'); return; }
+        const MAX = 25;
+        const picked = rows.slice(0, MAX);
+        if (rows.length > MAX) showToast('info', 'Trimmed', `Reporting the first ${MAX} of ${rows.length} selected findings.`);
+        const findings = picked.map((r) => {
+          const info = (r.raw && r.raw.info) || {};
+          const detailParts = [];
+          if (r.file) detailParts.push(`file: ${r.file}`);
+          if (info.line) detailParts.push(`line: ${info.line}`);
+          if (info.url) detailParts.push(`url: ${info.url}`);
+          if (info.matched || info.match) detailParts.push(`match: ${info.matched || info.match}`);
+          if (!detailParts.length && r.raw) {
+            try { detailParts.push(JSON.stringify(r.raw).slice(0, 400)); } catch (_) { /* ignore */ }
+          }
+          return {
+            target: String(r.target || r.host || ''),
+            finding_type: String(r.finding || r.title || ''),
+            severity: String(r.severity || ''),
+            module: String(r.module || ''),
+            detail: detailParts.join(' | '),
+          };
+        });
+        const orig = reportAiBtn.textContent;
+        reportAiBtn.disabled = true; reportAiBtn.textContent = ' Generating…';
+        try {
+          const res = await apiPost('/api/findings/report-batch', { findings });
+          showReportModal(`AI Report — ${picked.length} finding(s)`, String(res.report || '').trim() || '(empty response)');
+        } catch (e) {
+          showToast('error', 'Report failed', e.message || String(e));
+        } finally {
+          reportAiBtn.disabled = false; reportAiBtn.textContent = orig;
         }
       });
     }

--- a/internal/api/ui_api.go
+++ b/internal/api/ui_api.go
@@ -22,17 +22,18 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gin-gonic/gin"
+	"github.com/h0tak88r/AutoAR/internal/brain"
 	"github.com/h0tak88r/AutoAR/internal/db"
 	"github.com/h0tak88r/AutoAR/internal/envloader"
 	"github.com/h0tak88r/AutoAR/internal/r2storage"
 	"github.com/h0tak88r/AutoAR/internal/scanner/monitor"
 	"github.com/h0tak88r/AutoAR/internal/scanner/monitorsuggest"
+	"github.com/h0tak88r/AutoAR/internal/scanner/nuclei"
 	"github.com/h0tak88r/AutoAR/internal/scanner/subdomainmonitor"
 	"github.com/h0tak88r/AutoAR/internal/utils"
 	"github.com/h0tak88r/AutoAR/internal/version"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 	"github.com/projectdiscovery/nuclei/v3/pkg/output"
-	"github.com/h0tak88r/AutoAR/internal/scanner/nuclei"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2170,6 +2171,24 @@ func openRouterChat(c *gin.Context, systemPrompt, userPrompt string) (string, er
 	return result.Choices[0].Message.Content, nil
 }
 
+// aiChat routes a system+user prompt to the first available AI provider.
+// Preference: an OpenRouter key (UI X-OpenRouter-Key header or OPENROUTER_API_KEY)
+// is used first; otherwise (or if OpenRouter errors) it falls back to the shared
+// brain provider chain (OpenCode → Z.ai → Gemini). This keeps the dashboard AI
+// helpers working when the user only configured the free OpenCode provider.
+func aiChat(c *gin.Context, systemPrompt, userPrompt string) (string, error) {
+	hasOR := strings.TrimSpace(c.GetHeader("X-OpenRouter-Key")) != "" ||
+		strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")) != ""
+	if hasOR {
+		out, err := openRouterChat(c, systemPrompt, userPrompt)
+		if err == nil {
+			return out, nil
+		}
+		log.Printf("[API] OpenRouter chat failed, falling back to OpenCode/Gemini: %v", err)
+	}
+	return brain.ChatWithAI(nil, userPrompt, systemPrompt)
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/findings/validate — AI validates a single finding
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2214,7 +2233,7 @@ What can an attacker do? Be specific.
 ## Quick Fix
 One-line remediation.`, body.Target, body.FindingType, body.Severity, body.Module)
 
-	analysis, err := openRouterChat(c, systemPrompt, userPrompt)
+	analysis, err := aiChat(c, systemPrompt, userPrompt)
 	if err != nil {
 		log.Printf("[API] validate finding error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -2278,7 +2297,7 @@ Use EXACTLY this structure (markdown):
 ## Impact
 [1-2 sentences: what an attacker can do]`, body.Target, body.FindingType, body.Severity, body.Module)
 
-	report, err := openRouterChat(c, systemPrompt, userPrompt)
+	report, err := aiChat(c, systemPrompt, userPrompt)
 	if err != nil {
 		log.Printf("[API] report finding error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -2289,5 +2308,119 @@ Use EXACTLY this structure (markdown):
 		"report":  report,
 		"target":  body.Target,
 		"finding": body.FindingType,
+	})
+}
+
+// reportSystemPrompt is the attacker-mindset instruction enforcing the exact
+// report structure for the batch finding-report feature.
+const reportSystemPrompt = `You are a senior offensive security engineer writing bug bounty reports.
+
+Mindset:
+- Think like a real-world attacker, not a beginner.
+- Always look for practical, exploitable vulnerabilities.
+- Focus on impact, not theory.
+- Be concise, direct, and technical.
+
+When reporting a vulnerability:
+- ONLY use the following structure.
+- Keep it clean, concise, and professional.
+- No extra commentary outside the structure.
+
+## Title: <clear, specific vulnerability name>
+
+## Summary
+<short explanation of the issue and where it exists>
+
+## Steps to Reproduce
+1. <step 1>
+2. <step 2>
+3. <step 3>
+
+## Impact
+<realistic impact, what attacker can achieve>
+
+If multiple findings are provided, output one report per finding using EXACTLY this structure, separated by a line containing only '---'. If several findings are clearly the same vulnerability class on related assets, you may merge them into a single report and list all affected targets in the Summary.`
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/findings/report-batch — AI writes a report for one or many findings
+// ─────────────────────────────────────────────────────────────────────────────
+
+type reportFindingItem struct {
+	Target      string `json:"target"`
+	FindingType string `json:"finding_type"`
+	Severity    string `json:"severity"`
+	Module      string `json:"module"`
+	Detail      string `json:"detail"`
+}
+
+func apiReportFindingsBatch(c *gin.Context) {
+	var body struct {
+		Findings []reportFindingItem `json:"findings"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	// Keep only findings that carry an identifier, and cap the batch so the prompt
+	// (and cost/latency) stays bounded.
+	cleaned := make([]reportFindingItem, 0, len(body.Findings))
+	for _, f := range body.Findings {
+		if strings.TrimSpace(f.FindingType) == "" && strings.TrimSpace(f.Target) == "" {
+			continue
+		}
+		cleaned = append(cleaned, f)
+	}
+	if len(cleaned) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no findings provided"})
+		return
+	}
+	const maxBatch = 25
+	truncated := false
+	if len(cleaned) > maxBatch {
+		cleaned = cleaned[:maxBatch]
+		truncated = true
+	}
+
+	var sb strings.Builder
+	if len(cleaned) == 1 {
+		sb.WriteString("Write a vulnerability report for this finding.\n\n")
+	} else {
+		fmt.Fprintf(&sb, "Write a vulnerability report for the following %d findings.\n\n", len(cleaned))
+	}
+	for i, f := range cleaned {
+		fmt.Fprintf(&sb, "Finding %d:\n", i+1)
+		if v := strings.TrimSpace(f.Target); v != "" {
+			fmt.Fprintf(&sb, "- Target: %s\n", v)
+		}
+		if v := strings.TrimSpace(f.FindingType); v != "" {
+			fmt.Fprintf(&sb, "- Vulnerability: %s\n", v)
+		}
+		if v := strings.TrimSpace(f.Severity); v != "" {
+			fmt.Fprintf(&sb, "- Severity: %s\n", v)
+		}
+		if v := strings.TrimSpace(f.Module); v != "" {
+			fmt.Fprintf(&sb, "- Scanner/Module: %s\n", v)
+		}
+		if v := strings.TrimSpace(f.Detail); v != "" {
+			if len(v) > 600 {
+				v = v[:600]
+			}
+			fmt.Fprintf(&sb, "- Evidence: %s\n", v)
+		}
+		sb.WriteString("\n")
+	}
+
+	report, err := aiChat(c, reportSystemPrompt, sb.String())
+	if err != nil {
+		log.Printf("[API] batch report error: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"report":    report,
+		"count":     len(cleaned),
+		"truncated": truncated,
 	})
 }

--- a/internal/scanner/zerodays/zerodays.go
+++ b/internal/scanner/zerodays/zerodays.go
@@ -8,48 +8,49 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io"
 	"github.com/h0tak88r/AutoAR/internal/logger"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	next88 "github.com/h0tak88r/AutoAR/internal/tools/next88"
 	"github.com/h0tak88r/AutoAR/internal/scanner/livehosts"
+	next88 "github.com/h0tak88r/AutoAR/internal/tools/next88"
 	"github.com/h0tak88r/AutoAR/internal/utils"
-	"github.com/projectdiscovery/httpx/runner"
 	"github.com/projectdiscovery/goflags"
+	"github.com/projectdiscovery/httpx/runner"
 	naaburesult "github.com/projectdiscovery/naabu/v2/pkg/result"
 	naaburunner "github.com/projectdiscovery/naabu/v2/pkg/runner"
 )
 
 // Options for zerodays scan
 type Options struct {
-	Domain              string   // Domain to scan (or subdomain)
-	Subdomain           string   // Single subdomain to scan (alternative to Domain)
-	DomainsFile         string   // File with domains (one per line)
-	HostsFile           string   // Alias for DomainsFile, file with hosts/subdomains/IPs
-	URLs                []string // Direct URLs to test
-	Threads             int      // Number of threads
-	DOSTest             bool     // Enable DoS test for React2Shell
-	EnableSourceExposure bool   // Enable source exposure check for React2Shell
-	Silent              bool     // Silent mode
-	CVEs                []string // CVEs to check: "CVE-2025-55182" (React2Shell), "CVE-2025-14847" (MongoDB)
-	MongoDBHost         string   // MongoDB host (for CVE-2025-14847)
-	MongoDBPort         int      // MongoDB port (default: 27017)
-	MongoDBLeakSize     int      // Memory leak size in bytes (default: 65536)
+	Domain               string   // Domain to scan (or subdomain)
+	Subdomain            string   // Single subdomain to scan (alternative to Domain)
+	DomainsFile          string   // File with domains (one per line)
+	HostsFile            string   // Alias for DomainsFile, file with hosts/subdomains/IPs
+	URLs                 []string // Direct URLs to test
+	Threads              int      // Number of threads
+	DOSTest              bool     // Enable DoS test for React2Shell
+	EnableSourceExposure bool     // Enable source exposure check for React2Shell
+	Silent               bool     // Silent mode
+	CVEs                 []string // CVEs to check: "CVE-2025-55182" (React2Shell), "CVE-2025-14847" (MongoDB)
+	MongoDBHost          string   // MongoDB host (for CVE-2025-14847)
+	MongoDBPort          int      // MongoDB port (default: 27017)
+	MongoDBLeakSize      int      // Memory leak size in bytes (default: 65536)
 }
 
 // Result holds scan results
 type Result struct {
-	Domain              string
-	React2ShellVulns    []React2ShellFinding
-	MongoDBVulns       []MongoDBFinding
-	TotalHostsScanned  int
-	TotalVulnerable    int
+	Domain            string
+	React2ShellVulns  []React2ShellFinding
+	MongoDBVulns      []MongoDBFinding
+	TotalHostsScanned int
+	TotalVulnerable   int
 }
 
 // React2ShellFinding represents a React2Shell vulnerability finding
@@ -61,12 +62,12 @@ type React2ShellFinding struct {
 
 // MongoDBFinding represents a MongoDB CVE-2025-14847 vulnerability finding
 type MongoDBFinding struct {
-	Host        string
-	Port        int
-	Vulnerable  bool
-	LeakedData   []byte
-	LeakSize    int
-	Error       string
+	Host       string
+	Port       int
+	Vulnerable bool
+	LeakedData []byte
+	LeakSize   int
+	Error      string
 }
 
 // logInfo logs an info message only if not in silent mode
@@ -96,7 +97,6 @@ func Run(opts Options) (*Result, error) {
 		// Default: check all
 		cvesToCheck = []string{"CVE-2025-55182", "CVE-2025-14847"}
 	}
-
 
 	// Check React2Shell (CVE-2025-55182)
 	if contains(cvesToCheck, "CVE-2025-55182") {
@@ -131,7 +131,7 @@ func Run(opts Options) (*Result, error) {
 			} else if result.TotalHostsScanned == 0 {
 				result.TotalHostsScanned = count
 			}
-			
+
 			for _, v := range mongoResult {
 				if v.Vulnerable {
 					result.TotalVulnerable++
@@ -254,7 +254,7 @@ func checkReact2Shell(opts Options) ([]React2ShellFinding, int, error) {
 			if info, err := os.Stat(liveHostsFile); err != nil || info.Size() == 0 {
 				// File doesn't exist, check if this single subdomain URL is live
 				opts.logInfo("[INFO] Checking if subdomain %s is live (single URL check, no enumeration)...", subdomainClean)
-				
+
 				// Check if subdomain is live using httpx directly (no enumeration)
 				liveURL, err2 := checkSingleSubdomainLive(subdomainClean, opts.Threads)
 				if err2 != nil {
@@ -263,12 +263,12 @@ func checkReact2Shell(opts Options) ([]React2ShellFinding, int, error) {
 				if liveURL == "" {
 					return nil, 0, fmt.Errorf("subdomain %s is not live", subdomainClean)
 				}
-				
+
 				// Create directory if needed
 				if err := os.MkdirAll(subsDir, 0755); err != nil {
 					return nil, 0, fmt.Errorf("failed to create subs directory: %w", err)
 				}
-				
+
 				// Write the single live URL to file
 				if err := os.WriteFile(liveHostsFile, []byte(liveURL+"\n"), 0644); err != nil {
 					return nil, 0, fmt.Errorf("failed to write live hosts file: %w", err)
@@ -465,7 +465,7 @@ func checkMongoDB(opts Options) ([]MongoDBFinding, int, error) {
 	} else {
 		// No explicit host provided - discover MongoDB instances
 		var liveHostsFile string
-		
+
 		// Priority 1: Use explicit HostsFile/DomainsFile if provided
 		if opts.HostsFile != "" {
 			liveHostsFile = opts.HostsFile
@@ -477,16 +477,16 @@ func checkMongoDB(opts Options) ([]MongoDBFinding, int, error) {
 			if target == "" {
 				target = opts.Domain
 			}
-			
+
 			if target != "" {
 				// Clean target
 				targetClean := strings.TrimPrefix(strings.TrimPrefix(target, "http://"), "https://")
 				targetClean = strings.TrimSuffix(targetClean, "/")
-				
+
 				// Determine if it's a subdomain
 				parts := strings.Split(targetClean, ".")
 				isSubdomain := len(parts) > 2
-				
+
 				resultsDir := utils.GetResultsDir()
 				var domainDir string
 				if isSubdomain {
@@ -496,7 +496,7 @@ func checkMongoDB(opts Options) ([]MongoDBFinding, int, error) {
 				}
 				subsDir := filepath.Join(domainDir, "subs")
 				liveHostsFile = filepath.Join(subsDir, "live-subs.txt")
-				
+
 				// Check if live hosts file exists
 				if info, err := os.Stat(liveHostsFile); err != nil || info.Size() == 0 {
 					opts.logWarn("[WARN] Live hosts file not found for %s, skipping MongoDB discovery", targetClean)
@@ -507,18 +507,18 @@ func checkMongoDB(opts Options) ([]MongoDBFinding, int, error) {
 
 		if liveHostsFile != "" {
 			opts.logInfo("[INFO] Discovering MongoDB instances by scanning %s for port %d...", liveHostsFile, port)
-			
+
 			// Use naabu to scan hosts for MongoDB port
 			discoveredHosts, err := discoverMongoDBHosts(liveHostsFile, port, opts.Threads, opts.Silent)
 			if err != nil {
 				return nil, 0, fmt.Errorf("failed to discover MongoDB hosts: %w", err)
 			}
-			
+
 			if len(discoveredHosts) == 0 {
 				opts.logWarn("[INFO] No MongoDB instances found on port %d", port)
 				return findings, 0, nil
 			}
-			
+
 			mongoHosts = discoveredHosts
 			opts.logWarn("[INFO] Found %d MongoDB host(s) with port %d open", len(mongoHosts), port)
 		} else {
@@ -585,7 +585,7 @@ func testMongoDBVulnerability(host string, port, leakSize int, silent bool) Mong
 		LeakSize:   leakSize,
 	}
 
-	address := fmt.Sprintf("%s:%d", host, port)
+	address := net.JoinHostPort(host, strconv.Itoa(port))
 	if !silent {
 		logger.GetLogger().Infof("[INFO] Testing MongoDB CVE-2025-14847 on %s", address)
 	}
@@ -643,7 +643,7 @@ func testMongoDBVulnerability(host string, port, leakSize int, silent bool) Mong
 		if !silent {
 			logger.GetLogger().Infof("[OK] MongoDB CVE-2025-14847: Vulnerable! Leaked %d bytes from %s", len(leakedData), address)
 		}
-		
+
 	} else {
 		if !silent {
 			logger.GetLogger().Infof("[INFO] MongoDB CVE-2025-14847: Not vulnerable or patched on %s", address)
@@ -660,7 +660,7 @@ func buildMalformedMongoDBPacket(leakSize int) ([]byte, error) {
 	// BSON document: {"isMaster": 1}
 	bsonPayload := []byte{
 		0x13, 0x00, 0x00, 0x00, // Document length (19 bytes)
-		0x10, // String type
+		0x10,                                         // String type
 		'i', 's', 'M', 'a', 's', 't', 'e', 'r', 0x00, // "isMaster"
 		0x01, 0x00, 0x00, 0x00, // Value: 1 (int32)
 		0x00, // End of document
@@ -691,18 +691,18 @@ func buildMalformedMongoDBPacket(leakSize int) ([]byte, error) {
 
 	// 3. Construct malicious OP_COMPRESSED packet
 	opCompressed := make([]byte, 0)
-	
+
 	// originalOpcode: 2004 (OP_QUERY)
 	opCompressed = append(opCompressed, make([]byte, 4)...)
 	binary.LittleEndian.PutUint32(opCompressed[len(opCompressed)-4:], 2004)
-	
+
 	// uncompressedSize: MALICIOUS large value (the vulnerability)
 	opCompressed = append(opCompressed, make([]byte, 4)...)
 	binary.LittleEndian.PutUint32(opCompressed[len(opCompressed)-4:], uint32(leakSize))
-	
+
 	// compressorId: 2 (zlib)
 	opCompressed = append(opCompressed, 0x02)
-	
+
 	// compressed data
 	opCompressed = append(opCompressed, compressed...)
 
@@ -773,7 +773,7 @@ func runNext88Scan(ctx context.Context, hosts []string, args []string, requested
 	if err != nil {
 		return nil, fmt.Errorf("next88 scan failed: %w", err)
 	}
-	
+
 	// Convert results to map
 	for _, result := range scanResults {
 		if result.Vulnerable != nil && *result.Vulnerable {
@@ -859,26 +859,26 @@ func checkSingleSubdomainLive(subdomain string, threads int) (string, error) {
 	if threads <= 0 {
 		threads = 1 // Single URL, only need 1 thread
 	}
-	
+
 	// Try both http and https
 	targets := []string{
 		"https://" + subdomain,
 		"http://" + subdomain,
 	}
-	
+
 	var liveURL string
 	var mu sync.Mutex
-	
+
 	// Configure httpx options
 	options := runner.Options{
-		InputTargetHost: targets,
-		Threads:        threads,
-		Silent:         true,
-		NoColor:        true,
-		FollowRedirects: true,
+		InputTargetHost:     targets,
+		Threads:             threads,
+		Silent:              true,
+		NoColor:             true,
+		FollowRedirects:     true,
 		FollowHostRedirects: true,
-		HTTPProxy:      os.Getenv("HTTP_PROXY"),
-		SocksProxy:     os.Getenv("SOCKS_PROXY"),
+		HTTPProxy:           os.Getenv("HTTP_PROXY"),
+		SocksProxy:          os.Getenv("SOCKS_PROXY"),
 		OnResult: func(result runner.Result) {
 			if result.URL != "" {
 				mu.Lock()
@@ -889,22 +889,22 @@ func checkSingleSubdomainLive(subdomain string, threads int) (string, error) {
 			}
 		},
 	}
-	
+
 	// Validate options
 	if err := options.ValidateOptions(); err != nil {
 		return "", fmt.Errorf("failed to validate httpx options: %w", err)
 	}
-	
+
 	// Create httpx runner
 	httpxRunner, err := runner.New(&options)
 	if err != nil {
 		return "", fmt.Errorf("failed to create httpx runner: %w", err)
 	}
 	defer httpxRunner.Close()
-	
+
 	// Run check
 	httpxRunner.RunEnumeration()
-	
+
 	return liveURL, nil
 }
 
@@ -914,14 +914,14 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 	if threads <= 0 {
 		threads = 50
 	}
-	
+
 	// Read hosts from live hosts file
 	file, err := os.Open(liveHostsFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open live hosts file: %w", err)
 	}
 	defer file.Close()
-	
+
 	var hosts []string
 	scanner := bufio.NewScanner(file)
 	seen := make(map[string]struct{})
@@ -930,7 +930,7 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 		if line == "" {
 			continue
 		}
-		
+
 		// Extract hostname from URL
 		host := line
 		if strings.HasPrefix(host, "http://") {
@@ -944,7 +944,7 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 		if idx := strings.Index(host, ":"); idx != -1 {
 			host = host[:idx]
 		}
-		
+
 		if host == "" {
 			continue
 		}
@@ -954,28 +954,28 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 		seen[host] = struct{}{}
 		hosts = append(hosts, host)
 	}
-	
+
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("error reading live hosts file: %w", err)
 	}
-	
+
 	if len(hosts) == 0 {
 		return nil, fmt.Errorf("no hosts found in live hosts file")
 	}
-	
+
 	if !silent {
 		logger.GetLogger().Infof("[INFO] Scanning %d live host(s) for MongoDB port %d", len(hosts), mongoPort)
 	}
-	
+
 	// Use naabu to scan for MongoDB port
 	var mongoHosts []string
 	var mu sync.Mutex
-	
+
 	onResult := func(hr *naaburesult.HostResult) {
 		if hr == nil || len(hr.Ports) == 0 {
 			return
 		}
-		
+
 		// Extract hostname
 		host := hr.Host
 		if strings.HasPrefix(host, "http://") {
@@ -986,7 +986,7 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 		if idx := strings.Index(host, "/"); idx != -1 {
 			host = host[:idx]
 		}
-		
+
 		// Check if MongoDB port is open
 		for _, p := range hr.Ports {
 			if p != nil && p.Port == mongoPort {
@@ -1000,7 +1000,7 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 			}
 		}
 	}
-	
+
 	options := &naaburunner.Options{
 		Host:     goflags.StringSlice(hosts),
 		Ports:    fmt.Sprintf("%d", mongoPort),
@@ -1010,16 +1010,16 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 		Retries:  1,
 		OnResult: onResult,
 	}
-	
+
 	r, err := naaburunner.NewRunner(options)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create naabu runner: %w", err)
 	}
 	defer r.Close()
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
-	
+
 	if err := r.RunEnumeration(ctx); err != nil {
 		// Return discovered hosts even if scan had errors
 		if len(mongoHosts) > 0 {
@@ -1030,6 +1030,6 @@ func discoverMongoDBHosts(liveHostsFile string, mongoPort int, threads int, sile
 		}
 		return nil, fmt.Errorf("naabu scan failed: %w", err)
 	}
-	
+
 	return mongoHosts, nil
 }


### PR DESCRIPTION
## Summary

Fixes the failing CI pipeline, fixes an AI-provider gap introduced when OpenCode became the default, and adds a multi-finding AI report feature.

## What changed

### CI fix (the failing pipeline)
`CGO_ENABLED=1 go vet ./...` was failing with:
> `internal/scanner/zerodays/zerodays.go:588: address format "%s:%d" does not work with IPv6 (passed to net.Dial)`

The MongoDB dial address now uses `net.JoinHostPort(host, strconv.Itoa(port))` instead of `fmt.Sprintf("%s:%d", ...)`, which is IPv6-safe. Replicated the full CI sequence locally — `go vet`, `go build`, `go test ./...` (all `CGO_ENABLED=1`) — all pass.

### AI provider fallback
The dashboard "validate finding" and "report" helpers required OpenRouter specifically (`openRouterChat`, hardcoded `openai/gpt-4o-mini`). After OpenCode became the default free provider, a user who set only `OPENCODE_API_KEY` got *"No OpenRouter API key configured."*

New `aiChat()` helper tries OpenRouter first (UI `X-OpenRouter-Key` header or `OPENROUTER_API_KEY`), then falls back to the shared `brain.ChatWithAI` chain (OpenCode → Z.ai → Gemini). `apiValidateFinding` and `apiReportFinding` now use it.

### Multi-finding AI report (new feature)
- **Backend:** `POST /api/findings/report-batch` (`apiReportFindingsBatch`) accepts 1..N selected findings (capped at 25), builds a prompt from each finding's target/type/severity/module/evidence, and uses an attacker-mindset system prompt that enforces the exact `## Title / ## Summary / ## Steps to Reproduce / ## Impact` structure (one report per finding, separated by `---`; merges same-class findings). Routed through `aiChat`, so it works on any configured provider.
- **Frontend** (`scan-detail.js`): new **"Report selected (AI)"** toolbar button that reuses the existing finding checkboxes + select-all, collects the checked rows (with file/line/url/match evidence from `raw`), POSTs them, and shows the generated report in a copyable modal (Copy / Close / Esc).

### Programs cache hardening
`programsCacheEnabled()` gates the DB-backed programs cache on `DB_HOST`. Without a DB, the handler skips the cache + background refresh and just does a live fetch — preventing a DB-less deployment from looping expensive ~1000-call upstream rebuilds that can never be persisted.

## Reviewer notes
- `testing` was already merged to `master` earlier, so this PR is just the one new commit on top.
- No schema changes. No new dependencies.
- Verified locally: `CGO_ENABLED=1 go vet ./...`, `go build`, `go test ./...` all green; `node --check` on the modified JS passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)